### PR TITLE
Review and address GitHub issue #2

### DIFF
--- a/lib/igh_ethercat/nif.ex
+++ b/lib/igh_ethercat/nif.ex
@@ -308,7 +308,7 @@ defmodule IghEthercat.Nif do
           last_state = state;
           state = try do_get_master_state(master);
 
-          std.time.sleep(interval * std.time.ns_per_ms);
+          std.Thread.sleep(interval * std.time.ns_per_ms);
           try beam.yield();
       }
   }
@@ -416,7 +416,7 @@ defmodule IghEthercat.Nif do
           }
 
           counter +%= 1; // Wraps to 0
-          std.time.sleep(interval * std.time.ns_per_us);
+          std.Thread.sleep(interval * std.time.ns_per_us);
       }
   }
   """


### PR DESCRIPTION
Replace deprecated std.time.sleep() with std.Thread.sleep() in two locations:
- listen_bus_changes function (line 311)
- cyclic_task function (line 419)

The std.time.sleep() function was removed in Zig 0.15.2 and replaced with std.Thread.sleep().

Fixes #2