### PR TITLE
Fix incorrect sync manager domain constraint

### DIFF
--- a/ENTRY_LEVEL_REGISTRATION.md
+++ b/ENTRY_LEVEL_REGISTRATION.md
@@ -123,21 +123,22 @@ receive do
 end
 ```
 
-### Example 3: Different Domains per Sync Manager
+### Example 3: Multi-Rate Control with Different Domains
 
 ```elixir
 # Device with outputs (SM2) and inputs (SM3)
-# Can register them to different domains!
+# Different sync managers can use different domains (and even entries
+# from the SAME sync manager can use different domains!)
 
 {:ok, master, [slave]} = EtherCAT.open(index: 0)
 {:ok, _} = EtherCAT.create_domain(master, :fast_outputs, 1)
 {:ok, _} = EtherCAT.create_domain(master, :slow_inputs, 10)
 {:ok, _pdos} = EtherCAT.configure_slave(slave, %{})
 
-# Outputs to fast domain (1x base rate)
+# Outputs (SM2) to fast domain (1x base rate)
 {:ok, cmd} = EtherCAT.register_entry(master, slave, :output1, :command, :fast_outputs)
 
-# Inputs to slow domain (10x base rate)
+# Inputs (SM3) to slow domain (10x base rate)
 {:ok, status} = EtherCAT.register_entry(master, slave, :input1, :status, :slow_inputs)
 
 EtherCAT.start_cyclic(master)
@@ -187,34 +188,42 @@ receive do
 end
 ```
 
-### Example 5: Invalid - Sync Manager Conflict
+### Example 5: Multi-Rate Control with Same Sync Manager
 
 ```elixir
-# ❌ ERROR: Both :ch1 and :ch2 are in SM3, must use same domain
+# ✅ VALID: Entries from the same sync manager can go to different domains!
+# Each domain creates its own FMMU for independent access.
 
-{:ok, _} = EtherCAT.register_entry(master, slave, :ch1, :value, :fast)
-{:error, {:sync_manager_domain_conflict, msg}} =
-  EtherCAT.register_entry(master, slave, :ch2, :value, :slow)
+# Fast control loop (1ms) - critical position data
+{:ok, pos} = EtherCAT.register_entry(master, slave, :ch1, :value, :fast)
 
-# Error message:
-# "Sync manager 3 is already assigned to domain :fast.
-#  All entries from the same sync manager must use the same domain.
-#  This is an IgH EtherCAT Master constraint (see ecrt.h documentation)."
+# Slow monitoring (10ms) - diagnostic data from same sync manager
+{:ok, diag} = EtherCAT.register_entry(master, slave, :ch2, :value, :slow)
+
+# Both :ch1 and :ch2 are in SM3, but can use different domains.
+# The IgH Master creates one FMMU per domain for this sync manager.
 ```
 
-## Sync Manager Domain Constraint
+## Multi-Domain Registration and FMMUs
 
-**Important:** All entries from the same sync manager must be registered to the same domain.
+**Key Insight:** Entries from the same sync manager CAN be registered to different domains!
 
-### Why This Constraint Exists
+### How It Works
 
-When you register any entry from a sync manager to a domain, the IgH EtherCAT Master:
+When you register entries from a sync manager to different domains, the IgH EtherCAT Master:
 
-1. Configures an FMMU (Fieldbus Memory Management Unit) to map the **entire sync manager's memory** to that domain
-2. The sync manager provides synchronized access to that memory region
-3. Splitting a sync manager across domains would require splitting its synchronized memory access → architectural impossibility
+1. Creates one **FMMU (Fieldbus Memory Management Unit)** per domain
+2. Each FMMU independently maps the **same sync manager memory** to its domain's process data image
+3. This enables multi-rate control: critical data updates fast, diagnostic data updates slowly
 
-Reference: IgH EtherCAT Master `ecrt.h` documentation states "respective sync manager's assigned PDOs are appended to the given domain, **if not already done**"
+**Reference:** IgH EtherCAT Master documentation states "each domain occupies one FMMU in each slave involved"
+
+### FMMU Limit
+
+The only constraint is the **number of available FMMUs** per slave:
+- Typical slaves have 8-16 FMMUs
+- One FMMU is consumed per (domain × slave) combination
+- Example: 3 domains × 1 slave = 3 FMMUs used
 
 ### How to Know Which Entries Share a Sync Manager?
 
@@ -227,7 +236,7 @@ Reference: IgH EtherCAT Master `ecrt.h` documentation states "respective sync ma
 # Example EL3202:
 # :ch1 → SM3 (inputs)
 # :ch2 → SM3 (inputs)
-# Both must use same domain!
+# Both CAN use different domains - each gets its own FMMU!
 ```
 
 ### Valid Domain Assignments
@@ -236,7 +245,7 @@ Reference: IgH EtherCAT Master `ecrt.h` documentation states "respective sync ma
 |----------|--------|--------|
 | `:ch1:value` → `:fast`, `:ch1:error` → `:fast` | ✅ Yes | Same PDO, same SM, same domain |
 | `:ch1:value` → `:fast`, `:ch2:value` → `:fast` | ✅ Yes | Different PDOs, same SM3, same domain |
-| `:ch1:value` → `:fast`, `:ch2:value` → `:slow` | ❌ No | Different PDOs, same SM3, **different domains** |
+| `:ch1:value` → `:fast`, `:ch2:value` → `:slow` | ✅ **YES!** | Different PDOs, same SM3, **different domains** (uses 2 FMMUs) |
 | `:output1` (SM2) → `:fast`, `:input1` (SM3) → `:slow` | ✅ Yes | **Different SMs**, can use different domains |
 
 ## API Reference
@@ -259,8 +268,8 @@ Registers a single PDO entry.
 **Errors:**
 - `{:invalid_state, :unconfigured, msg}` - Must call `configure/2` first
 - `{:entry_not_found, entry_name, msg}` - Entry doesn't exist in PDO
-- `{:sync_manager_domain_conflict, msg}` - SM already assigned to different domain
 - `{:slave_operational, msg}` - Cannot register after master activation
+- `{:error, :domain_not_found}` - Specified domain doesn't exist
 
 ### `EtherCAT.register_entries/4`
 

--- a/lib/ethercat.ex
+++ b/lib/ethercat.ex
@@ -104,8 +104,9 @@ defmodule EtherCAT do
   - `{:ok, %PDO{}}` - PDO handle for read/write/watch operations
   - `{:error, reason}` - Error if registration fails
 
-  ## Sync Manager Constraint
-  All entries from the same sync manager must use the same domain.
+  ## Multi-Domain Support
+  Entries from the same sync manager can be registered to different domains.
+  Each domain creates its own FMMU mapping of the sync manager memory.
 
   ## Example
 
@@ -191,8 +192,9 @@ defmodule EtherCAT do
   - `{:ok, [%PDO{}]}` - List of handles for all entries in all PDOs
   - `{:error, reason}` - Error if registration fails
 
-  ## Sync Manager Constraint
-  All PDOs from the same sync manager must use the same domain.
+  ## Multi-Domain Support
+  PDOs and entries can be registered to different domains regardless of sync manager.
+  Each domain creates its own FMMU for accessing the sync manager memory.
 
   ## Example
 

--- a/lib/ethercat/slave.ex
+++ b/lib/ethercat/slave.ex
@@ -37,18 +37,23 @@ defmodule EtherCAT.Slave do
       # Register all 6 entries from channel 1
       {:ok, handles} = Slave.register_pdo(slave, :ch1)
 
-  ## Sync Manager Domain Constraint
+  ## Multi-Domain Registration
 
-  **Important:** All entries from the same sync manager must be registered to the same domain.
+  Entries from the same sync manager CAN be registered to different domains.
+  Each domain creates its own FMMU (Fieldbus Memory Management Unit) mapping of the
+  sync manager's memory.
 
-  This is an IgH EtherCAT Master constraint: when any entry from a sync manager is registered
-  to a domain, the entire sync manager's process data is mapped to that domain via FMMU.
+  This enables multi-rate control systems where different entries update at different rates:
 
-  Different sync managers CAN use different domains (e.g., SM2 outputs → fast_domain,
-  SM3 inputs → slow_domain).
+      # Fast control loop (1ms): Register critical entries
+      {:ok, position} = Slave.register_entry(slave, :status, :position, :fast_domain)
 
-  Reference: ecrt.h documentation - "respective sync manager's assigned PDOs are appended
-  to the given domain, if not already done"
+      # Slow monitoring (10ms): Register diagnostic entries
+      {:ok, temp} = Slave.register_entry(slave, :status, :temperature, :slow_domain)
+
+  The only hardware limit is the number of available FMMUs per slave (typically 8-16).
+
+  Reference: IgH EtherCAT Master documentation - "each domain occupies one FMMU in each slave involved"
   """
 
   @behaviour :gen_statem
@@ -72,8 +77,6 @@ defmodule EtherCAT.Slave do
     :name,
     # Tracks registered entries per PDO: %{pdo_name => %{domain: atom(), entries: MapSet}}
     pdo_registrations: %{},
-    # Tracks sync manager to domain mapping: %{sync_index => domain_name}
-    sync_manager_domains: %{},
     # Tracks which sync managers have been configured (one-time setup)
     configured_sync_managers: MapSet.new()
   ]
@@ -92,7 +95,6 @@ defmodule EtherCAT.Slave do
           sync_count: non_neg_integer(),
           name: atom() | String.t() | nil,
           pdo_registrations: %{pdo_name() => %{domain: domain(), entries: MapSet.t(atom())}},
-          sync_manager_domains: %{non_neg_integer() => domain()},
           configured_sync_managers: MapSet.t(non_neg_integer())
         }
 
@@ -266,8 +268,9 @@ defmodule EtherCAT.Slave do
   - `{:ok, unique_name}` - Unique entry identifier like "slave_0:ch1:value"
   - `{:error, reason}` - Error if registration fails
 
-  ## Sync Manager Constraint
-  All entries from the same sync manager must use the same domain.
+  ## Multi-Domain Support
+  Entries from the same sync manager can be registered to different domains.
+  Each domain uses a separate FMMU to access the same sync manager memory.
 
   ## Example
 
@@ -346,8 +349,8 @@ defmodule EtherCAT.Slave do
   **IMPORTANT:**
   - You must call `Slave.configure/2` before calling this function.
   - This registers all entries defined in the PDO by the driver.
-  - Different PDOs from different sync managers can go to different domains.
-  - All PDOs from the same sync manager must use the same domain.
+  - Entries/PDOs can be registered to different domains regardless of sync manager.
+  - Each domain creates its own FMMU mapping.
 
   ## Parameters
   - `slave` - The slave process PID
@@ -735,7 +738,6 @@ defmodule EtherCAT.Slave do
   defp do_register_entry(pdo_name, entry_name, domain_name, data) do
     with {:ok, pdo_info} <- data.driver.pdo_info(data.driver_state, pdo_name),
          :ok <- validate_entry_exists(pdo_info, entry_name),
-         :ok <- validate_sync_manager_domain(pdo_info, domain_name, data),
          {:ok, domain_pid} <- Domain.find_domain(data.master, domain_name) do
       {sync_index, direction, watchdog} = pdo_info.sync_manager
       pdo_index = pdo_info.pdo_index
@@ -799,13 +801,9 @@ defmodule EtherCAT.Slave do
           fn reg -> %{reg | entries: MapSet.put(reg.entries, entry_name)} end
         )
 
-      updated_sm_domains =
-        Map.put_new(updated_data.sync_manager_domains, sync_index, domain_name)
-
       final_data = %{
         updated_data
-        | pdo_registrations: updated_registrations,
-          sync_manager_domains: updated_sm_domains
+        | pdo_registrations: updated_registrations
       }
 
       Logger.debug(
@@ -854,29 +852,6 @@ defmodule EtherCAT.Slave do
       {:error,
        {:entry_not_found, entry_name,
         "Available entries: #{available}"}}
-    end
-  end
-
-  # Validates sync manager to domain mapping constraint
-  defp validate_sync_manager_domain(pdo_info, domain_name, data) do
-    {sync_index, _direction, _watchdog} = pdo_info.sync_manager
-
-    case Map.get(data.sync_manager_domains, sync_index) do
-      nil ->
-        # First registration from this sync manager - OK
-        :ok
-
-      ^domain_name ->
-        # Same domain - OK
-        :ok
-
-      other_domain ->
-        # Different domain - ERROR
-        {:error,
-         {:sync_manager_domain_conflict,
-          "Sync manager #{sync_index} is already assigned to domain #{inspect(other_domain)}. " <>
-            "All entries from the same sync manager must use the same domain. " <>
-            "This is an IgH EtherCAT Master constraint (see ecrt.h documentation)."}}
     end
   end
 


### PR DESCRIPTION
This commit fixes a critical bug in the sync manager domain validation logic.

**What was wrong:**
- Previously enforced constraint: "All entries from the same sync manager must use the same domain"
- This constraint was INCORRECT based on IgH EtherCAT Master documentation

**What is correct (per IgH docs):**
- Entries from the same sync manager CAN be registered to different domains
- Each domain creates its own FMMU (Fieldbus Memory Management Unit)
- Multiple FMMUs can map the same sync manager memory independently
- Quote: "each domain occupies one FMMU in each slave involved"

**Changes made:**
1. Removed sync_manager_domains tracking from Slave struct
2. Removed validate_sync_manager_domain/3 function with incorrect validation
3. Updated all documentation (Slave.ex, ethercat.ex, ENTRY_LEVEL_REGISTRATION.md)
4. Changed Example 5 from "Invalid" to valid multi-rate control example
5. Updated "Sync Manager Domain Constraint" section to "Multi-Domain Registration"
6. Added correct FMMU explanation throughout documentation

**Impact:**
This fix enables proper multi-rate control systems where different entries from the same sync manager update at different rates (e.g., critical position data at 1ms, diagnostic data at 10ms).

**Hardware limit:**
The only constraint is the number of FMMUs per slave (typically 8-16).