### PR TITLE
Package Setup and Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,30 @@ end
 
 **Requirements:** IgH EtherCAT Master (libethercat + kernel module), Zig 0.15.2, Elixir 1.19+, Linux
 
+## Configuration
+
+By default, the library looks for IgH EtherCAT headers and libraries at:
+- **Host:** `/usr/local/include` and `/usr/local/lib64`
+- **Nerves:** Auto-detected from `NERVES_SDK_SYSROOT`
+
+Override these paths in your application config if needed:
+
+```elixir
+# config/config.exs or config/host.exs
+config :ethercat,
+  igh_include_dir: "/opt/etherlab/include",
+  igh_lib_dir: "/opt/etherlab/lib"
+```
+
+For Nerves projects, paths are automatically detected from the sysroot. You can override them in `config/target.exs` if using a custom Nerves system:
+
+```elixir
+# config/target.exs
+config :ethercat,
+  igh_include_dir: "#{System.get_env("NERVES_SDK_SYSROOT")}/usr/include",
+  igh_lib_dir: "#{System.get_env("NERVES_SDK_SYSROOT")}/usr/lib"
+```
+
 ## Quick Start
 
 ```elixir

--- a/lib/ethercat/nif.ex
+++ b/lib/ethercat/nif.ex
@@ -1,11 +1,24 @@
 defmodule EtherCAT.Nif do
   @moduledoc false
 
+  @nerves_sysroot System.get_env("NERVES_SDK_SYSROOT")
+
+  @default_include_dir if @nerves_sysroot,
+                          do: Path.join(@nerves_sysroot, "usr/include"),
+                          else: "/usr/local/include"
+
+  @default_lib_dir if @nerves_sysroot,
+                      do: Path.join(@nerves_sysroot, "usr/lib"),
+                      else: "/usr/local/lib64"
+
+  @include_dir Application.compile_env(:ethercat, :igh_include_dir, @default_include_dir)
+  @lib_dir Application.compile_env(:ethercat, :igh_lib_dir, @default_lib_dir)
+
   use Zig,
     otp_app: :ethercat,
-    leak_check: true,
     c: [
-      include_dirs: "/usr/local/include/",
+      include_dirs: @include_dir,
+      library_dirs: [@lib_dir],
       link_lib: {:system, "ethercat"}
     ],
     nifs: [


### PR DESCRIPTION
- Add :igh_include_dir and :igh_lib_dir config options
- Auto-detect Nerves sysroot via NERVES_SDK_SYSROOT env var
- Default to /usr/local/include and /usr/local/lib64 for host
- Remove leak_check option (development-only overhead)
- Document configuration in README with examples

Enables cross-compilation for Nerves systems while maintaining host development flexibility. Consuming applications can override paths via application config.