### PR TITLE
Review BEAM OTP process registration patterns

### DIFF
--- a/lib/ethercat/master.ex
+++ b/lib/ethercat/master.ex
@@ -8,7 +8,7 @@ defmodule EtherCAT.Master do
 
   alias EtherCAT.{Nif, Slave, Domain}
 
-  defstruct [:master_ref, :slaves, :domains, :task_pid, :update_interval]
+  defstruct [:master_ref, :slaves, :domains, :task_pid, :update_interval, :nif_yield_interval]
 
   @type t :: %__MODULE__{
           master_ref: reference(),
@@ -16,7 +16,9 @@ defmodule EtherCAT.Master do
           domains: [Domain.t()],
           task_pid: pid(),
           # in us
-          update_interval: integer()
+          update_interval: integer(),
+          # NIF yielding interval in us (default 100_000 = 100ms)
+          nif_yield_interval: integer()
         }
 
   # Client API
@@ -37,13 +39,28 @@ defmodule EtherCAT.Master do
     }
   end
 
-  @doc "Starts master process in `:offline` state."
+  @doc """
+  Starts master process in `:offline` state.
+
+  ## Options
+  - `:master_index` - EtherCAT master index (default: 0)
+  - `:update_interval` - Master update interval in microseconds (default: 10_000)
+  - `:nif_yield_interval` - NIF yielding interval in microseconds (default: 100_000 = 100ms)
+  - `:name` - Registered process name (default: `EtherCAT.Master`)
+  """
   @spec start_link(keyword()) :: {:ok, pid()} | {:error, term()}
   def start_link(opts \\ []) do
     master_index = Keyword.get(opts, :master_index, 0)
     update_interval = Keyword.get(opts, :update_interval, 10_000)
+    nif_yield_interval = Keyword.get(opts, :nif_yield_interval, 100_000)
     name = Keyword.get(opts, :name, __MODULE__)
-    :gen_statem.start_link({:local, name}, __MODULE__, {master_index, update_interval}, [])
+
+    :gen_statem.start_link(
+      {:local, name},
+      __MODULE__,
+      {master_index, update_interval, nif_yield_interval},
+      []
+    )
   end
 
   @doc """
@@ -126,7 +143,7 @@ defmodule EtherCAT.Master do
   def callback_mode(), do: [:state_functions, :state_enter]
 
   @impl true
-  def init({master_index, update_interval}) do
+  def init({master_index, update_interval, nif_yield_interval}) do
     # Trap exits to ensure graceful cleanup
     Process.flag(:trap_exit, true)
 
@@ -135,7 +152,8 @@ defmodule EtherCAT.Master do
         # Register this master in the Registry for process discovery
         case Registry.register(EtherCAT.Registry, {:master, master_index}, %{
                master_index: master_index,
-               update_interval: update_interval
+               update_interval: update_interval,
+               nif_yield_interval: nif_yield_interval
              }) do
           {:ok, _} ->
             :ok
@@ -153,7 +171,8 @@ defmodule EtherCAT.Master do
               domains: [domain_pid],
               slaves: [],
               task_pid: nil,
-              update_interval: update_interval
+              update_interval: update_interval,
+              nif_yield_interval: nif_yield_interval
             }
 
             Logger.info("EtherCAT Master #{master_index} initialized successfully")
@@ -469,7 +488,13 @@ defmodule EtherCAT.Master do
 
         task_pid =
           spawn_link(fn ->
-            Nif.cyclic_task(parent_pid, data.master_ref, domain_resources, data.update_interval)
+            Nif.cyclic_task(
+              parent_pid,
+              data.master_ref,
+              domain_resources,
+              data.update_interval,
+              data.nif_yield_interval
+            )
           end)
 
         duration = System.monotonic_time() - start_time

--- a/lib/ethercat/nif.ex
+++ b/lib/ethercat/nif.ex
@@ -134,9 +134,6 @@ defmodule EtherCAT.Nif do
   /// Maximum number of PDO entries per domain to prevent unbounded growth
   const MAX_ENTRIES_PER_DOMAIN = 1024;
 
-  /// Interval for yielding to BEAM scheduler (microseconds)
-  const YIELD_INTERVAL_US = 100_000;
-
   // ============================================================================
   // TYPE DEFINITIONS
   // ============================================================================
@@ -896,12 +893,19 @@ defmodule EtherCAT.Nif do
   /// Change detection: Compares domain buffer with stored values, notifies BEAM
   /// processes for inputs. For outputs, writes stored values to domain buffer.
   ///
-  /// BEAM integration: Yields every 100ms to prevent scheduler starvation.
-  pub fn cyclic_task(master_pid: beam.pid, master_resource: MasterResource, domain_accessors: []DomainAccessorResource, interval: u64) !void {
+  /// BEAM integration: Yields at configurable intervals to prevent scheduler starvation.
+  ///
+  /// ## Parameters
+  /// - `master_pid` - PID of the master process
+  /// - `master_resource` - Master resource reference
+  /// - `domain_accessors` - List of domain accessor resources
+  /// - `interval` - Cyclic task interval in microseconds
+  /// - `nif_yield_interval` - Yielding interval in microseconds (default: 100_000 = 100ms)
+  pub fn cyclic_task(master_pid: beam.pid, master_resource: MasterResource, domain_accessors: []DomainAccessorResource, interval: u64, nif_yield_interval: u64) !void {
       const master = master_resource.unpack();
       var master_state: master_state_t = undefined;
       var prev_master_state: master_state_t = undefined;
-      const yield_interval = @divTrunc(YIELD_INTERVAL_US, interval); // Yield every 100ms
+      const yield_interval = @divTrunc(nif_yield_interval, interval); // Calculate yield interval in cycles
 
       // Initialize domain data pointers for all domain accessors
       for (domain_accessors) |domain_accessor_resource| {


### PR DESCRIPTION
Changes:
- Add nif_yield_interval parameter to Master state and start_link options
- Default remains 100ms (100_000 microseconds) for backward compatibility
- Remove hardcoded YIELD_INTERVAL_US constant from nif.ex
- Update cyclic_task to accept configurable yield interval parameter
- Add documentation for tuning guidelines

Benefits:
- Allows fine-tuning for different cycle times and performance requirements
- Improves flexibility for real-time applications with varying latency needs
- Enables testing with different yielding strategies

Usage:
  # Default 100ms Master.start_link(master_index: 0)

  # Custom 50ms for high-frequency sampling Master.start_link(master_index: 0, nif_yield_interval: 50_000)