### PR TITLE
Fix Spark DSL functionality issue

### DIFF
--- a/lib/ethercat/config.ex
+++ b/lib/ethercat/config.ex
@@ -72,12 +72,33 @@ defmodule EtherCAT.Config do
         }
       end)
 
+    # Extract driver module from driver entity
+    driver =
+      case entity.driver do
+        nil -> nil
+        driver_entity -> driver_entity.module
+      end
+
+    # Convert expect entity to expected map format
+    expected =
+      case entity.expect do
+        nil -> nil
+        expect -> %{vendor: expect.vendor, product: expect.product}
+      end
+
+    # Extract config fields if config entity exists
+    config =
+      case entity.config do
+        nil -> %{}
+        config -> config.__fields__ || %{}
+      end
+
     %EtherCAT.Config.SlaveConfig{
       position: entity.position,
       name: entity.name,
-      driver: entity.driver,
-      expected: entity.expected,
-      config: entity.config || %{},
+      driver: driver,
+      expected: expected,
+      config: config,
       entries: entries
     }
   end
@@ -149,6 +170,21 @@ defmodule EtherCAT.Config do
                 ]
               }
             ],
+            driver: [
+              %Spark.Dsl.Entity{
+                name: :driver,
+                describe: "Driver module for this slave",
+                target: EtherCAT.Config.Dsl.Driver,
+                args: [:module],
+                schema: [
+                  module: [
+                    type: :atom,
+                    required: true,
+                    doc: "Driver module (e.g., EtherCAT.Drivers.EL3202)"
+                  ]
+                ]
+              }
+            ],
             config: [
               %Spark.Dsl.Entity{
                 name: :config,
@@ -158,9 +194,29 @@ defmodule EtherCAT.Config do
                 schema: [],
                 recursive_as: :config
               }
+            ],
+            expect: [
+              %Spark.Dsl.Entity{
+                name: :expect,
+                describe: "Expected vendor and product IDs for slave verification",
+                target: EtherCAT.Config.Dsl.Expect,
+                args: [],
+                schema: [
+                  vendor: [
+                    type: :non_neg_integer,
+                    required: true,
+                    doc: "Expected vendor ID"
+                  ],
+                  product: [
+                    type: :non_neg_integer,
+                    required: true,
+                    doc: "Expected product code"
+                  ]
+                ]
+              }
             ]
           ],
-          singleton_entity_keys: [:driver, :expected]
+          singleton_entity_keys: [:driver, :expect, :config]
         }
       ]
     }

--- a/lib/ethercat/config/dsl/driver.ex
+++ b/lib/ethercat/config/dsl/driver.ex
@@ -1,0 +1,7 @@
+defmodule EtherCAT.Config.Dsl.Driver do
+  @moduledoc false
+  # Entity target for driver DSL
+  # Captures the driver module for a slave
+
+  defstruct [:module, :__spark_metadata__]
+end

--- a/lib/ethercat/config/dsl/expect.ex
+++ b/lib/ethercat/config/dsl/expect.ex
@@ -1,0 +1,7 @@
+defmodule EtherCAT.Config.Dsl.Expect do
+  @moduledoc false
+  # Entity target for expect DSL block
+  # Captures vendor and product ID expectations
+
+  defstruct [:vendor, :product, :__spark_metadata__]
+end

--- a/lib/ethercat/config/dsl/slave.ex
+++ b/lib/ethercat/config/dsl/slave.ex
@@ -5,10 +5,10 @@ defmodule EtherCAT.Config.Dsl.Slave do
   defstruct [
     :position,
     :name,
-    :driver,
-    :expected,
-    :config,
+    :driver,    # Will be a Driver entity (singleton)
+    :expect,    # Will be an Expect entity (singleton)
+    :config,    # Will be a Config entity (singleton)
     :__spark_metadata__,
-    entries: []
+    entries: []  # Will be a list of Entry entities
   ]
 end

--- a/test/config_dsl_test.exs
+++ b/test/config_dsl_test.exs
@@ -1,0 +1,95 @@
+defmodule EtherCATConfigDslTest do
+  use ExUnit.Case
+
+  defmodule TestConfig do
+    use EtherCAT.Config
+
+    domain :fast_loop, interval: 1
+    domain :slow_loop, interval: 10
+
+    slave do
+      position 0
+      name :temp_sensor
+      driver EtherCAT.Drivers.EL3202
+
+      expect do
+        vendor 0x00000002
+        product 0x0C5A3052
+      end
+
+      config do
+        limit1 1000
+        limit2 2000
+        filter :enabled
+      end
+
+      entry :ch1, :value, domain: :fast_loop
+      entry :ch1, :error, domain: :slow_loop
+      entry :ch2, :value, domain: :fast_loop
+    end
+
+    slave do
+      position 1
+      name :valve_outputs
+      driver EtherCAT.Drivers.EL2008
+
+      entry :ch1, :value, domain: :fast_loop
+      entry :ch2, :value, domain: :fast_loop
+    end
+  end
+
+  test "DSL compiles and builds configuration" do
+    config = TestConfig.hardware_config()
+
+    assert %EtherCAT.Config.HardwareConfig{} = config
+    assert length(config.domains) == 2
+    assert length(config.slaves) == 2
+  end
+
+  test "domains are configured correctly" do
+    config = TestConfig.hardware_config()
+
+    fast_loop = Enum.find(config.domains, &(&1.name == :fast_loop))
+    assert fast_loop.interval == 1
+
+    slow_loop = Enum.find(config.domains, &(&1.name == :slow_loop))
+    assert slow_loop.interval == 10
+  end
+
+  test "slaves are configured correctly" do
+    config = TestConfig.hardware_config()
+
+    temp_sensor = Enum.find(config.slaves, &(&1.name == :temp_sensor))
+    assert temp_sensor.position == 0
+    assert temp_sensor.driver == EtherCAT.Drivers.EL3202
+    assert temp_sensor.expected == %{vendor: 0x00000002, product: 0x0C5A3052}
+    assert length(temp_sensor.entries) == 3
+
+    valve_outputs = Enum.find(config.slaves, &(&1.name == :valve_outputs))
+    assert valve_outputs.position == 1
+    assert valve_outputs.driver == EtherCAT.Drivers.EL2008
+    assert length(valve_outputs.entries) == 2
+  end
+
+  test "entries are configured correctly" do
+    config = TestConfig.hardware_config()
+    temp_sensor = Enum.find(config.slaves, &(&1.name == :temp_sensor))
+
+    ch1_value = Enum.find(temp_sensor.entries, &(&1.pdo_name == :ch1 && &1.entry_name == :value))
+    assert ch1_value.domain == :fast_loop
+
+    ch1_error = Enum.find(temp_sensor.entries, &(&1.pdo_name == :ch1 && &1.entry_name == :error))
+    assert ch1_error.domain == :slow_loop
+  end
+
+  test "config block is captured" do
+    config = TestConfig.hardware_config()
+    temp_sensor = Enum.find(config.slaves, &(&1.name == :temp_sensor))
+
+    # Config should be a map with the specified fields
+    assert is_map(temp_sensor.config)
+    assert temp_sensor.config.limit1 == 1000
+    assert temp_sensor.config.limit2 == 2000
+    assert temp_sensor.config.filter == :enabled
+  end
+end


### PR DESCRIPTION
The Spark DSL was broken because singleton_entity_keys referenced entity keys (:driver, :expected) that didn't exist in the entities keyword list.

Changes:
- Created Driver and Expect entity structs
- Added driver and expect as proper singleton entities in slave config
- Updated singleton_entity_keys to reference actual entities: [:driver, :expect, :config]
- Modified build_slave/1 to extract values from singleton entities
- Renamed :expected to :expect in Slave struct for consistency

This enables the declarative DSL syntax:
  slave position: 0, name: :temp_sensor do driver EtherCAT.Drivers.EL3202 expect vendor: 0x00000002, product: 0x0C5A3052 end

Fixes the singleton_entity_keys validation error that prevented DSL compilation.