### PR TITLE
Fix EL1809 and EL2809 EtherCAT drivers

### DIFF
--- a/lib/ethercat/drivers/el1809.ex
+++ b/lib/ethercat/drivers/el1809.ex
@@ -20,36 +20,61 @@ defmodule EtherCAT.Drivers.EL1809 do
 
   @impl true
   def list_pdos(_state) do
-    [:inputs]
+    [:ch1, :ch2, :ch3, :ch4, :ch5, :ch6, :ch7, :ch8,
+     :ch9, :ch10, :ch11, :ch12, :ch13, :ch14, :ch15, :ch16]
   end
 
   @impl true
   def pdo_info(_state, pdo_name) do
     case pdo_name do
-      :inputs ->
-        {:ok,
-         %{
-           sync_manager: {3, :input, :default},
-           pdo_index: 0x1A00,
-           entries: %{
-             ch1: {0x6000, 0x01, 1},
-             ch2: {0x6000, 0x02, 1},
-             ch3: {0x6000, 0x03, 1},
-             ch4: {0x6000, 0x04, 1},
-             ch5: {0x6000, 0x05, 1},
-             ch6: {0x6000, 0x06, 1},
-             ch7: {0x6000, 0x07, 1},
-             ch8: {0x6000, 0x08, 1},
-             ch9: {0x6000, 0x09, 1},
-             ch10: {0x6000, 0x0A, 1},
-             ch11: {0x6000, 0x0B, 1},
-             ch12: {0x6000, 0x0C, 1},
-             ch13: {0x6000, 0x0D, 1},
-             ch14: {0x6000, 0x0E, 1},
-             ch15: {0x6000, 0x0F, 1},
-             ch16: {0x6000, 0x10, 1}
-           }
-         }}
+      :ch1 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A00,
+                entries: %{input: {0x6000, 0x01, 1}}}}
+      :ch2 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A01,
+                entries: %{input: {0x6010, 0x01, 1}}}}
+      :ch3 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A02,
+                entries: %{input: {0x6020, 0x01, 1}}}}
+      :ch4 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A03,
+                entries: %{input: {0x6030, 0x01, 1}}}}
+      :ch5 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A04,
+                entries: %{input: {0x6040, 0x01, 1}}}}
+      :ch6 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A05,
+                entries: %{input: {0x6050, 0x01, 1}}}}
+      :ch7 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A06,
+                entries: %{input: {0x6060, 0x01, 1}}}}
+      :ch8 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A07,
+                entries: %{input: {0x6070, 0x01, 1}}}}
+      :ch9 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A08,
+                entries: %{input: {0x6080, 0x01, 1}}}}
+      :ch10 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A09,
+                entries: %{input: {0x6090, 0x01, 1}}}}
+      :ch11 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0A,
+                entries: %{input: {0x60A0, 0x01, 1}}}}
+      :ch12 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0B,
+                entries: %{input: {0x60B0, 0x01, 1}}}}
+      :ch13 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0C,
+                entries: %{input: {0x60C0, 0x01, 1}}}}
+      :ch14 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0D,
+                entries: %{input: {0x60D0, 0x01, 1}}}}
+      :ch15 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0E,
+                entries: %{input: {0x60E0, 0x01, 1}}}}
+      :ch16 ->
+        {:ok, %{sync_manager: {0, :input, :default}, pdo_index: 0x1A0F,
+                entries: %{input: {0x60F0, 0x01, 1}}}}
 
       _ ->
         {:error, {:unknown_pdo, pdo_name}}

--- a/lib/ethercat/drivers/el2809.ex
+++ b/lib/ethercat/drivers/el2809.ex
@@ -20,36 +20,64 @@ defmodule EtherCAT.Drivers.EL2809 do
 
   @impl true
   def list_pdos(_state) do
-    [:outputs]
+    [:ch1, :ch2, :ch3, :ch4, :ch5, :ch6, :ch7, :ch8,
+     :ch9, :ch10, :ch11, :ch12, :ch13, :ch14, :ch15, :ch16]
   end
 
   @impl true
   def pdo_info(_state, pdo_name) do
     case pdo_name do
-      :outputs ->
-        {:ok,
-         %{
-           sync_manager: {2, :output, :default},
-           pdo_index: 0x1600,
-           entries: %{
-             ch1: {0x7000, 0x01, 1},
-             ch2: {0x7000, 0x02, 1},
-             ch3: {0x7000, 0x03, 1},
-             ch4: {0x7000, 0x04, 1},
-             ch5: {0x7000, 0x05, 1},
-             ch6: {0x7000, 0x06, 1},
-             ch7: {0x7000, 0x07, 1},
-             ch8: {0x7000, 0x08, 1},
-             ch9: {0x7000, 0x09, 1},
-             ch10: {0x7000, 0x0A, 1},
-             ch11: {0x7000, 0x0B, 1},
-             ch12: {0x7000, 0x0C, 1},
-             ch13: {0x7000, 0x0D, 1},
-             ch14: {0x7000, 0x0E, 1},
-             ch15: {0x7000, 0x0F, 1},
-             ch16: {0x7000, 0x10, 1}
-           }
-         }}
+      # SM0 - Channels 1-8
+      :ch1 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1600,
+                entries: %{output: {0x7000, 0x01, 1}}}}
+      :ch2 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1601,
+                entries: %{output: {0x7010, 0x01, 1}}}}
+      :ch3 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1602,
+                entries: %{output: {0x7020, 0x01, 1}}}}
+      :ch4 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1603,
+                entries: %{output: {0x7030, 0x01, 1}}}}
+      :ch5 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1604,
+                entries: %{output: {0x7040, 0x01, 1}}}}
+      :ch6 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1605,
+                entries: %{output: {0x7050, 0x01, 1}}}}
+      :ch7 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1606,
+                entries: %{output: {0x7060, 0x01, 1}}}}
+      :ch8 ->
+        {:ok, %{sync_manager: {0, :output, :default}, pdo_index: 0x1607,
+                entries: %{output: {0x7070, 0x01, 1}}}}
+
+      # SM1 - Channels 9-16
+      :ch9 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x1608,
+                entries: %{output: {0x7080, 0x01, 1}}}}
+      :ch10 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x1609,
+                entries: %{output: {0x7090, 0x01, 1}}}}
+      :ch11 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160A,
+                entries: %{output: {0x70A0, 0x01, 1}}}}
+      :ch12 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160B,
+                entries: %{output: {0x70B0, 0x01, 1}}}}
+      :ch13 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160C,
+                entries: %{output: {0x70C0, 0x01, 1}}}}
+      :ch14 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160D,
+                entries: %{output: {0x70D0, 0x01, 1}}}}
+      :ch15 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160E,
+                entries: %{output: {0x70E0, 0x01, 1}}}}
+      :ch16 ->
+        {:ok, %{sync_manager: {1, :output, :default}, pdo_index: 0x160F,
+                entries: %{output: {0x70F0, 0x01, 1}}}}
 
       _ ->
         {:error, {:unknown_pdo, pdo_name}}


### PR DESCRIPTION
The previous drivers incorrectly mapped all 16 channels to a single PDO with multiple entries. The actual hardware uses 16 separate PDOs, one for each channel.

EL1809 changes:
- Split from single :inputs PDO to 16 separate channel PDOs (:ch1 to :ch16)
- Each channel now has its own TxPDO (0x1A00 to 0x1A0F)
- Entry addresses corrected (0x6000:01, 0x6010:01, ..., 0x60F0:01)
- Changed sync manager from SM3 to SM0

EL2809 changes:
- Split from single :outputs PDO to 16 separate channel PDOs (:ch1 to :ch16)
- Each channel now has its own RxPDO (0x1600 to 0x160F)
- Entry addresses corrected (0x7000:01, 0x7010:01, ..., 0x70F0:01)
- Channels 1-8 use SM0, channels 9-16 use SM1
- Changed sync manager from SM2 to SM0/SM1