### PR TITLE
Update hardware config tests for new API

### DIFF
--- a/lib/ethercat/config.ex
+++ b/lib/ethercat/config.ex
@@ -34,7 +34,7 @@ defmodule EtherCAT.Config do
       end
 
       # Use the configuration
-      {:ok, system} = EtherCAT.open(MyMachine)
+      {:ok, system} = EtherCAT.configure_hardware(0, MyMachine)
       {:ok, temp} = EtherCAT.read(system, :temp_sensor, :ch1, :value)
   """
 

--- a/test/hardware/rtd_input_test.exs
+++ b/test/hardware/rtd_input_test.exs
@@ -39,7 +39,7 @@ defmodule Hardware.RTDInputTest do
 
   describe "Basic Resistance Reading" do
     setup do
-      {:ok, system} = EtherCAT.configure_hardware(HardwareConfig)
+      {:ok, system} = EtherCAT.configure_hardware(0, HardwareConfig)
       on_exit(fn -> EtherCAT.stop_system(system) end)
       {:ok, system: system}
     end
@@ -89,7 +89,7 @@ defmodule Hardware.RTDInputTest do
 
   describe "Measurement Stability" do
     setup do
-      {:ok, system} = EtherCAT.configure_hardware(HardwareConfig)
+      {:ok, system} = EtherCAT.configure_hardware(0, HardwareConfig)
       on_exit(fn -> EtherCAT.stop_system(system) end)
       {:ok, system: system}
     end
@@ -159,7 +159,7 @@ defmodule Hardware.RTDInputTest do
 
   describe "Rapid Reading" do
     setup do
-      {:ok, system} = EtherCAT.configure_hardware(HardwareConfig)
+      {:ok, system} = EtherCAT.configure_hardware(0, HardwareConfig)
       on_exit(fn -> EtherCAT.stop_system(system) end)
       {:ok, system: system}
     end
@@ -207,7 +207,7 @@ defmodule Hardware.RTDInputTest do
 
   describe "Range Validation" do
     setup do
-      {:ok, system} = EtherCAT.configure_hardware(HardwareConfig)
+      {:ok, system} = EtherCAT.configure_hardware(0, HardwareConfig)
       on_exit(fn -> EtherCAT.stop_system(system) end)
       {:ok, system: system}
     end


### PR DESCRIPTION
Updates all test files and documentation to use the new two-phase init API:
- Fix rtd_input_test.exs to consistently pass master index (0) to configure_hardware
- Update Config module documentation to show correct API (configure_hardware instead of open)
- Ensure all tests use the same API pattern: EtherCAT.configure_hardware(0, HardwareConfig)

The test/support/hardware_config.ex was already using the correct API with cycle_interval and proper configuration structure, so no changes were needed there.